### PR TITLE
Fix to revision property on DivinityModVersion2

### DIFF
--- a/DivinityModManagerCore/Models/DivinityModVersion2.cs
+++ b/DivinityModManagerCore/Models/DivinityModVersion2.cs
@@ -124,7 +124,7 @@ namespace DivinityModManager.Models
 			*/
 			major = versionInt >> 55;
 			minor = (versionInt >> 47) & 0xFF;
-			revision = (versionInt >> 31) & 0x7FFFF;
+			revision = (versionInt >> 31) & 0xFFFF;
 			build = versionInt & 0x7FFFFFFFUL;
 			if (update)
 			{


### PR DESCRIPTION
I believe the revision is not being calculated properly
Py code for how I checked the `ParseVersionInt`
```python
>>> def ToVersionInt(major:int, minor:int, revision:int, build:int):
...     return (major << 55) + (minor << 47) + (revision << 31) + build
... 
>>> def ParseVersionInt(version:int):
...     major = version >> 55
...     minor = (version >> 47) & 0xFF
...     revision = (version >> 31) & 0xFFFF
...     build = version & 0x7FFFFFFF
...     return (major,minor,revision,build)
... 
>>> ToVersionInt(3,4,5,6)
108649351747731462
>>> ParseVersionInt(108649351747731462)
(3, 4, 5, 6)
>>> 
```