### PR TITLE
fix(gui): fix .csproj dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,11 @@ ASALocalRun/
 .vscode/settings.json
 GUI/DivinityModManager.ico
 PublishRelease.py
+
+# LSlib dll
+/DivinityModManagerCore/LSLib.dll
+/DivinityModManagerCore/LSLibNative.dll
+/DivinityModManagerCore/LZ4.dll
+/DivinityModManagerCore/OpenTK.dll
+/DivinityModManagerCore/QUT.ShiftReduceParser.dll
+/DivinityModManagerCore/zlib.net.dll

--- a/.gitignore
+++ b/.gitignore
@@ -348,10 +348,5 @@ ASALocalRun/
 GUI/DivinityModManager.ico
 PublishRelease.py
 
-# LSlib dll
-/DivinityModManagerCore/LSLib.dll
-/DivinityModManagerCore/LSLibNative.dll
-/DivinityModManagerCore/LZ4.dll
-/DivinityModManagerCore/OpenTK.dll
-/DivinityModManagerCore/QUT.ShiftReduceParser.dll
-/DivinityModManagerCore/zlib.net.dll
+# LSlib DLLs
+/External/lslib

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -579,17 +579,4 @@
     </GetAssemblyIdentity>
     <Exec Command="python &quot;BuildRelease.py&quot; &quot;%(AssemblyVersion.Version)&quot;" WorkingDirectory="$(SolutionDir)" />
   </Target>
-  <Import Project="..\packages\Fody.6.6.3\build\Fody.targets" Condition="Exists('..\packages\Fody.6.6.3\build\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.6.6.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.6.3\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\ReactiveUI.Fody.18.2.9\build\ReactiveUI.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactiveUI.Fody.18.2.9\build\ReactiveUI.Fody.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets'))" />
-    <Error Condition="!Exists('..\packages\Fody.6.8.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.8.0\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\ReactiveUI.Fody.19.4.1\build\ReactiveUI.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactiveUI.Fody.19.4.1\build\ReactiveUI.Fody.props'))" />
-  </Target>
-  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets')" />
-  <Import Project="..\packages\Fody.6.8.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.8.0\build\Fody.targets')" />
 </Project>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -579,4 +579,14 @@
     </GetAssemblyIdentity>
     <Exec Command="python &quot;BuildRelease.py&quot; &quot;%(AssemblyVersion.Version)&quot;" WorkingDirectory="$(SolutionDir)" />
   </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.8.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.8.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\ReactiveUI.Fody.19.4.1\build\ReactiveUI.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactiveUI.Fody.19.4.1\build\ReactiveUI.Fody.props'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\Microsoft.Web.WebView2.targets')" />
+  <Import Project="..\packages\Fody.6.8.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.8.0\build\Fody.targets')" />
 </Project>


### PR DESCRIPTION
This PR fixes a misconfiguration of the GUI project. The current configuration was preventing any build for a new dev because it was requiring Fody version `6.6.3` AND version `6.6.8` at the same time.

I removed the faulty configuration since it is deprecated with more up-to-date versions of Visual Studio anyway. See this [SO answer](https://stackoverflow.com/a/23852183) and related comments.