### PR TITLE
Add Game/GUI/Assets/ControllerUIIcons/items_png as ignored path

### DIFF
--- a/GUI/Resources/IgnoredMods.json
+++ b/GUI/Resources/IgnoredMods.json
@@ -10,7 +10,8 @@
 	"9dff4c3b-fda7-43de-a763-ce1383039999"
   ],
   "IgnoreBuiltinPath": [
-	"Game/GUI/Assets/Tooltips"
+	"Game/GUI/Assets/Tooltips",
+	"Game/GUI/Assets/ControllerUIIcons/items_png"
   ],
   "Mods": [
 	{


### PR DESCRIPTION
This is another folder like `Game/GUI/Assets/Tooltips` which contains the controller version of new icons needed to make the icons visible on the controller radial.