### PR TITLE
ci: initial CI & CD

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,57 @@
+name: main
+
+on: 
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs: 
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get LSLib
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://github.com/${{ vars.LSLIB_GITHUB }}/releases/download/${{ vars.LSLIB_VERSION }}/lslib-release.zip -OutFile lslib.zip
+          Expand-Archive -Path lslib.zip -DestinationPath external/lslib
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.x'
+
+      - name: Restore
+        run: dotnet restore BG3ModManager.sln
+
+      - name: Build
+        run: dotnet msbuild BG3ModManager.sln -p:Configuration=Publish
+
+      - name: Uploading artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BUILD
+          path: ./BG3ModManager_Latest.zip
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - uses: actions/download-artifact@v4
+        id: download
+        with:
+          name: BUILD
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{steps.download.outputs.download-path}}/BG3ModManager_Latest.zip


### PR DESCRIPTION
Basic CI/CD pipeline for LSLib.

Goal/Idea: streamline the release of BG3ModManager

Workflow:
- Creating a PR or pushing to master: will make a build, validating or not the changes
- Creating a tag or release: will make a build and create or update release with 2 artifacts (release and debug)

Setup:
- Require https://github.com/LaughingLeader/lslib/pull/1
- Require 3 Actions variables as ([how-to](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository)): 
  - `LSLIB_GITHUB`: `LaughingLeader/lslib` 
  - `LSLIB_VERSION`: `v1.18.5.0` (or any tag)

Demo: 
- Build: https://github.com/Herve-M/BG3ModManager/actions/runs/7328205442
- PR validation: https://github.com/Herve-M/BG3ModManager/pull/1
- Release: https://github.com/Herve-M/BG3ModManager/releases/tag/v1.0.10.0