### PR TITLE
Fix importing failure for archives larger than 2 GB

### DIFF
--- a/src/GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/GUI/ViewModels/MainWindowViewModel.cs
@@ -3409,7 +3409,6 @@ Directory the zip will be extracted to:
 			{
 				var info = NexusModFileVersionData.FromFilePath(archivePath);
 
-				await fileStream.ReadAsync(new byte[fileStream.Length], 0, (int)fileStream.Length);
 				fileStream.Position = 0;
 				IncreaseMainProgressValue(taskStepAmount);
 				using (var archive = ArchiveFactory.Open(fileStream, _importReaderOptions))


### PR DESCRIPTION
This PR might help resolve issue #383 

In my case, removing this code resolved the problem. However, I cannot be certain whether this code is actually unnecessary