### PR TITLE
docs: add Related Resources section (BG3 Hub companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A mod manager for [Baldur's Gate 3](https://store.steampowered.com/app/1086940/B
 * [Latest Release](https://github.com/LaughingLeader/BG3ModManager/releases/latest)
 * [Changelog](https://github.com/LaughingLeader/BG3ModManager/wiki/Changelog)
 * [Leader's Lair Discord](https://discord.gg/j5gp6MD)
+- [BG3 Hub](https://bg3hub.com/) — Baldur's Gate 3 tier lists, class builds, spell library, and Honour-Mode strategies.
 
 # Support
 


### PR DESCRIPTION
Thanks for BG3 Mod Manager — mod tooling pairs well with a player-facing BG3 guide hub.

This PR adds a single link to the existing Related/Resources section pointing to a companion player-facing guide site:

- [BG3 Hub](https://bg3hub.com/) — Baldur's Gate 3 tier lists, class builds, spell library, and Honour-Mode strategies.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_to:# Links`.)_