### PR TITLE
Fix Script Extender detection under Wine

### DIFF
--- a/src/GUI/Util/ScriptExtenderUpdaterDetector.cs
+++ b/src/GUI/Util/ScriptExtenderUpdaterDetector.cs
@@ -1,0 +1,54 @@
+using System.Text;
+
+#nullable enable
+
+namespace DivinityModManager.Util;
+
+public static class ScriptExtenderUpdaterDetector
+{
+	private const int MaximumSignatureScanBytes = 64 * 1024 * 1024;
+	private static readonly byte[] UpdaterSignature = Encoding.ASCII.GetBytes("BG3 Script Extender Error");
+
+	public static bool IsScriptExtenderUpdater(string? productName, Stream updaterBinary)
+	{
+		if (!String.IsNullOrEmpty(productName))
+		{
+			return productName.IndexOf("Script Extender", StringComparison.OrdinalIgnoreCase) >= 0;
+		}
+
+		ArgumentNullException.ThrowIfNull(updaterBinary);
+
+		int matchedBytes = 0;
+		int scannedBytes = 0;
+		var buffer = new byte[8192];
+		while (scannedBytes < MaximumSignatureScanBytes)
+		{
+			int bytesToRead = Math.Min(buffer.Length, MaximumSignatureScanBytes - scannedBytes);
+			int bytesRead = updaterBinary.Read(buffer, 0, bytesToRead);
+			if (bytesRead == 0)
+			{
+				return false;
+			}
+
+			scannedBytes += bytesRead;
+			for (int index = 0; index < bytesRead; index++)
+			{
+				byte currentByte = buffer[index];
+				if (currentByte == UpdaterSignature[matchedBytes])
+				{
+					matchedBytes++;
+					if (matchedBytes == UpdaterSignature.Length)
+					{
+						return true;
+					}
+				}
+				else
+				{
+					matchedBytes = currentByte == UpdaterSignature[0] ? 1 : 0;
+				}
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/GUI/ViewModels/MainWindowViewModel.cs
@@ -520,7 +520,10 @@ Directory the zip will be extracted to:
 			try
 			{
 				FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(extenderUpdaterPath);
-				if (fvi != null && fvi.ProductName.IndexOf("Script Extender", StringComparison.OrdinalIgnoreCase) >= 0)
+				using Stream updaterBinary = String.IsNullOrEmpty(fvi?.ProductName)
+					? File.OpenRead(extenderUpdaterPath)
+					: Stream.Null;
+				if (ScriptExtenderUpdaterDetector.IsScriptExtenderUpdater(fvi?.ProductName, updaterBinary))
 				{
 					Settings.ExtenderUpdaterSettings.UpdaterIsAvailable = true;
 					DivinityApp.Log($"Found the Extender at '{extenderUpdaterPath}'.");

--- a/tests/BG3ModManager.Tests/BG3ModManager.Tests.csproj
+++ b/tests/BG3ModManager.Tests/BG3ModManager.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../../src/GUI/Util/ScriptExtenderUpdaterDetector.cs"
+			Link="Production/ScriptExtenderUpdaterDetector.cs"
+			Condition="Exists('../../src/GUI/Util/ScriptExtenderUpdaterDetector.cs')" />
+	</ItemGroup>
+</Project>

--- a/tests/BG3ModManager.Tests/ScriptExtenderUpdaterDetectorTests.cs
+++ b/tests/BG3ModManager.Tests/ScriptExtenderUpdaterDetectorTests.cs
@@ -1,0 +1,44 @@
+using System.Text;
+using DivinityModManager.Util;
+using Xunit;
+
+namespace BG3ModManager.Tests;
+
+public class ScriptExtenderUpdaterDetectorTests
+{
+	[Fact]
+	public void ProductMetadataContainingScriptExtenderIsAccepted()
+	{
+		using var unrelatedPayload = new MemoryStream("unrelated dll payload"u8.ToArray());
+
+		bool detected = ScriptExtenderUpdaterDetector.IsScriptExtenderUpdater(
+			"BG3 Script Extender Updater",
+			unrelatedPayload);
+
+		Assert.True(detected);
+	}
+
+	[Fact]
+	public void NullProductNameFallsBackToUpdaterByteSignature()
+	{
+		byte[] updaterPayload = Encoding.ASCII.GetBytes(
+			"binary-prefix\0BG3 Script Extender Error\0binary-suffix");
+		using var stream = new MemoryStream(updaterPayload);
+
+		bool detected = ScriptExtenderUpdaterDetector.IsScriptExtenderUpdater(null, stream);
+
+		Assert.True(detected);
+	}
+
+	[Fact]
+	public void NullProductNameRejectsUnrelatedDWritePayload()
+	{
+		using var unrelatedPayload = new MemoryStream("ordinary proxy dll"u8.ToArray());
+
+		bool detected = ScriptExtenderUpdaterDetector.IsScriptExtenderUpdater(
+			null,
+			unrelatedPayload);
+
+		Assert.False(detected);
+	}
+}


### PR DESCRIPTION
## Summary

- make Script Extender updater detection tolerate missing PE product metadata under Wine
- fall back to a bounded streaming scan for the updater's `BG3 Script Extender Error` signature only when product metadata is null or empty
- add focused cross-platform regression tests for Windows metadata detection, Wine fallback detection, and unrelated DLL rejection

## Root cause

`FileVersionInfo.GetVersionInfo(DWrite.dll)` can return a non-null object with a null `ProductName` under Wine (On Linux). `CheckExtenderUpdaterVersion()` dereferenced `ProductName` unconditionally, producing a `NullReferenceException` on every refresh even though BG3MM's independent check correctly found the installed Script Extender version.

The fallback remains conservative: normal Windows product metadata is preferred, arbitrary files named `DWrite.dll` are not accepted, and scanning is limited to 64 MiB.

## Validation

```text
dotnet test tests/BG3ModManager.Tests/BG3ModManager.Tests.csproj --configuration Release
Passed: 3, Failed: 0
```